### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This is a Model Context Protocol (MCP) server that provides comprehensive SQLite
 - Database exploration and introspection
 - Execute custom SQL queries
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/jparkerweb-mcp-sqlite).
+
 ## Setup
 
 Define the command in your IDE's MCP Server settings:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/jparkerweb-mcp-sqlite).